### PR TITLE
Fix für #11 (behebt Problem bei Drag & Drop der Verbinder)

### DIFF
--- a/app/fpb/context-pad/FpbContextPadProvider.js
+++ b/app/fpb/context-pad/FpbContextPadProvider.js
@@ -69,7 +69,7 @@ FpbContextPadProvider.prototype.getContextPadEntries = function (element) {
       let hint;
       let className;
       // Unterscheidung ob Verbindung über MouseClick oder Touch
-      if (event.type == 'click') {
+      if (event.type == 'click' || event.type == 'dragstart') {
         className = event.srcElement.className;
       } else {
         className = event.srcEvent.srcElement.className;


### PR DESCRIPTION
Einfacher Fix für #11 (das Problem mit Drag & Drop der Verbinder).
Stellt sicher, dass sowohl bei Mausklick als auch bei "Dragstart" der className aus dem Event gezogen wird.